### PR TITLE
Add backend domain env var for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+BACKEND_DOMAIN=https://privium.com/api/privium

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Este repositorio contiene la aplicación web de **Privium**, un marketplace priv
 
 ### Configuración de entorno
 La comunicación con la API utiliza los archivos de `src/environments`.
-Modifica `environment.ts` para desarrollo y `environment.prod.ts` para
-producción indicando la URL base del backend.
+Ahora el dominio del backend se lee de la variable de entorno `BACKEND_DOMAIN`.
+Puedes copiar `.env.example` y ajustar el valor según tu servidor.
+`environment.ts` y `environment.prod.ts` toman ese valor durante la compilación.
 
 ## Uso
 ### Servidor de desarrollo de Angular

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://privium.com/api/privium'
+  apiBaseUrl:
+    import.meta.env.BACKEND_DOMAIN || 'https://privium.com/api/privium',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8080/api/privium'
+  apiBaseUrl:
+    import.meta.env.BACKEND_DOMAIN || 'http://localhost:8080/api/privium',
 };

--- a/src/environments/importMeta.d.ts
+++ b/src/environments/importMeta.d.ts
@@ -1,0 +1,6 @@
+interface ImportMetaEnv {
+  readonly BACKEND_DOMAIN?: string;
+}
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- read `BACKEND_DOMAIN` environment variable in Angular environments
- provide TypeScript definitions for `import.meta.env`
- document environment variable usage in README
- include `.env.example` template

## Testing
- `npx ng build` *(fails: fonts can't be fetched offline)*

------
https://chatgpt.com/codex/tasks/task_e_688c336793748330bd593232149898f3