### PR TITLE
Add Dockerfile for Angular front

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.gitignore
+.next

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+ARG BACKEND_DOMAIN
+ENV BACKEND_DOMAIN=${BACKEND_DOMAIN}
+RUN npx ng build --configuration=production
+
+# Production stage
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist/neighborhood-marketplace /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ npx ng build
 ```
 Los archivos listos para desplegar quedarán en `dist/`.
 
+### Docker
+Para crear una imagen de contenedor ejecuta:
+```bash
+docker build -t privium-front .
+```
+Esto compila la aplicación con Angular y la sirve mediante Nginx.
+Puedes definir el dominio del backend con la variable de construcción `BACKEND_DOMAIN`:
+```bash
+docker build --build-arg BACKEND_DOMAIN=https://mi.backend.com/api/privium -t privium-front .
+```
+Una vez creada la imagen, inicia el contenedor con:
+```bash
+docker run -p 4200:80 privium-front
+```
+
 ### Prototipos con Next.js
 En la carpeta `components` se encuentran componentes UI basados en React. Para probarlos se utilizó un pequeño proyecto de Next.js presente en la carpeta `app`. Para levantar dicho entorno ejecuta:
 ```bash


### PR DESCRIPTION
## Summary
- add Dockerfile and `.dockerignore`
- document docker usage in Spanish README

## Testing
- `npx ng build` *(fails: 403 fetching fonts)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c3d2f0c0c83308ca504af61f897cb