### PR TITLE
Make header responsive for mobile

### DIFF
--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -20,7 +20,11 @@
     </div>
 
     <!-- Barra de búsqueda -->
-    <div class="search-container" *ngIf="logged && !publishing">
+    <div
+      class="search-container"
+      *ngIf="logged && !publishing"
+      [ngClass]="{ 'mobile-open': isMobileMenuOpen }"
+    >
       <mat-form-field appearance="outline" class="search-field">
         <mat-icon matPrefix aria-hidden="true">search</mat-icon>
         <input
@@ -97,6 +101,16 @@
         </button>
       </mat-menu>
     </div>
+
+    <!-- Botón menú móvil -->
+    <button
+      mat-icon-button
+      class="mobile-menu-toggle"
+      (click)="toggleMobileMenu()"
+      aria-label="Menú de navegación"
+    >
+      <mat-icon>{{ isMobileMenuOpen ? 'close' : 'menu' }}</mat-icon>
+    </button>
   </div>
 </div>
 
@@ -105,6 +119,7 @@
   class="category-nav"
   aria-label="Navegación de categorías"
   *ngIf="logged && !publishing"
+  [ngClass]="{ 'mobile-open': isMobileMenuOpen }"
 >
   <div class="nav-container">
     <!-- Ubicación del usuario -->

--- a/src/app/shared/components/header/header.component.scss
+++ b/src/app/shared/components/header/header.component.scss
@@ -160,6 +160,11 @@ $container-w: 86%; // igual que el footer
   }
 }
 
+// Botón de menú para móviles oculto por defecto
+.mobile-menu-toggle {
+  display: none;
+}
+
 .user-info {
   padding: 1rem;
   display: flex;
@@ -321,6 +326,21 @@ $container-w: 86%; // igual que el footer
   .search-container {
     order: 3;
     width: 100%;
+  }
+
+  .mobile-menu-toggle {
+    display: block;
+    color: $white;
+  }
+
+  .search-container,
+  .category-nav {
+    display: none;
+  }
+
+  .search-container.mobile-open,
+  .category-nav.mobile-open {
+    display: block;
   }
 }
 

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -70,6 +70,9 @@ export class HeaderComponent implements OnInit {
   @ViewChild('catButton', { read: ElementRef })
   catButtonRef!: ElementRef<HTMLElement>;
 
+  /** Controla la visibilidad del menú en pantallas pequeñas */
+  isMobileMenuOpen = false;
+
   @Input() logged = true;
   @Input() publishing = false;
 
@@ -240,5 +243,10 @@ export class HeaderComponent implements OnInit {
 
   goToPublish(): void {
     this.router.navigate(["/publish"]);
+  }
+
+  /** Abre o cierra el menú móvil */
+  toggleMobileMenu(): void {
+    this.isMobileMenuOpen = !this.isMobileMenuOpen;
   }
 }


### PR DESCRIPTION
## Summary
- add mobile menu toggle logic in header component
- show/hide search and category nav for small screens
- style header mobile layout

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install --legacy-peer-deps` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688ce1d7793c8330aab4ed7e547e4591