### PR TITLE
Improve mobile responsive styling for result messages

### DIFF
--- a/src/app/features/profile/residence-verification/residence-verification.component.scss
+++ b/src/app/features/profile/residence-verification/residence-verification.component.scss
@@ -57,6 +57,13 @@
   padding: 80px 10px;
 }
 
+@media (max-width: $breakpoint-md) {
+  .rv-warn {
+    width: 100% !important;
+    padding: 40px 16px;
+  }
+}
+
 /* Tarjeta ocupa todo el ancho */
 .rv-card {
   width: 100%;

--- a/src/app/shared/components/result-warn/result-warn.component.scss
+++ b/src/app/shared/components/result-warn/result-warn.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../shared/styles/variables'; 
+@import '../../../../shared/styles/variables';
 
 /* Contenedor principal */
 .rw-container {
@@ -66,8 +66,7 @@
     align-self: flex-start;
     min-width: 260px;
     font-size: 1.2rem;
-    padding: 22px;
-    align-self: flex-end;
+    padding: 22px 32px;
   }
 }
 
@@ -81,16 +80,18 @@
 }
 
 /* Responsivo */
-@media (max-width: 768px) {
+@media (max-width: $breakpoint-md) {
   .rw-container {
     flex-direction: column;
     text-align: center;
     gap: 24px;
+    padding: 32px 24px;
   }
 
   .rw-icon {
     width: 120px;
     height: 120px;
+    border-width: 12px;
     mat-icon {
       font-size: 64px;
       width: 64px;
@@ -98,7 +99,28 @@
     }
   }
 
+  .rw-texts {
+    width: 100%;
+    gap: 16px;
+
+    .rw-title {
+      font-size: 1.8rem;
+    }
+
+    .rw-subtitle {
+      font-size: 1.3rem;
+    }
+
+    .rw-description {
+      font-size: 1rem;
+      max-width: none;
+    }
+  }
+
   .rw-btn {
     align-self: center;
+    min-width: 180px;
+    padding: 14px 24px;
+    font-size: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- adjust responsive layout for success/error messages
- update residence verification styles for smaller screens

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce2ee674c8330be1102c543c2814e