### PR TITLE
Improve mobile filters

### DIFF
--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -15,6 +15,14 @@
     <main class="search-main">
       <!-- Título -->
       <div class="search-title">
+        <button
+          mat-icon-button
+          class="hamburger"
+          aria-label="Mostrar filtros"
+          (click)="openFilters()"
+        >
+          <mat-icon>menu</mat-icon>
+        </button>
         <mat-icon>search</mat-icon>
         <h1>
           Búsqueda<b *ngIf="current.searchTerm">": {{ current.searchTerm }}"</b>

--- a/src/app/features/search/search.component.scss
+++ b/src/app/features/search/search.component.scss
@@ -119,8 +119,18 @@
   }
 }
 
+
 .filters-drawer {
   width: 300px;
+  @media (min-width: 900px) {
+    display: none;
+  }
+}
+
+.desktop-only {
+  @media (max-width: 900px) {
+    display: none;
+  }
 }
 
 .hamburger {

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -175,6 +175,10 @@ export class SearchComponent implements OnInit {
     this.drawer?.close();
   }
 
+  openFilters() {
+    this.drawer?.open();
+  }
+
   setSort(order: "ASC" | "DESC") {
     if (this.sortOrder === order) return;
     this.sortOrder = order;


### PR DESCRIPTION
## Summary
- make search-filters drawer visible only on mobile
- hide desktop filter sidebar on mobile
- show hamburger to open filters and handle click

## Testing
- `npx ng version`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_688ce345d2208330bbcb31cef3976bd3