### PR TITLE
Improve product card responsiveness

### DIFF
--- a/src/app/features/home/components/home/home.component.html
+++ b/src/app/features/home/components/home/home.component.html
@@ -44,7 +44,7 @@
           </div>
         </div>
 
-        <div class="products-grid" *ngIf="neighborhoodProducts.length">
+        <div class="products-grid nearby-products-grid" *ngIf="neighborhoodProducts.length">
           <app-product-card-small
             *ngFor="let p of neighborhoodProducts; trackBy: trackByProductId"
             [product]="p">

--- a/src/app/features/home/components/home/home.component.scss
+++ b/src/app/features/home/components/home/home.component.scss
@@ -49,7 +49,7 @@
 }
 
 app-product-card-small{
-  width: 85%;
+  width: 90%;
 }
 
 // Container con menos padding
@@ -104,6 +104,18 @@ app-product-card-small{
   }
 }
 
+.nearby-products-grid {
+  grid-template-columns: repeat(2, 1fr);
+
+  app-product-card-small {
+    width: 100%;
+  }
+
+  @media (max-width: 600px) {
+    grid-template-columns: 1fr;
+  }
+}
+
 // Category Sections - Menos padding
 .category-section {
   padding: 2rem 0;
@@ -124,16 +136,11 @@ app-product-card-small{
 
 .products-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 1rem; // Reducido
   justify-items: center;
   
   @media (max-width: 1400px) {
-    gap: 1rem;
-  }
-  
-  @media (max-width: 1200px) {
-    grid-template-columns: repeat(3, 1fr);
     gap: 1rem;
   }
   

--- a/src/app/shared/components/product-card-small/product-card-small.component.scss
+++ b/src/app/shared/components/product-card-small/product-card-small.component.scss
@@ -94,3 +94,39 @@
     }
   }
 }
+
+@media (max-width: $breakpoint-md) {
+  .product-card {
+    border-width: 3px;
+
+    mat-card-content {
+      padding: 10px 20px 10px 10px;
+
+      .price {
+        font-size: 1.2rem;
+      }
+
+      .title {
+        font-size: 0.95rem;
+      }
+
+      .location {
+        font-size: 0.8rem;
+      }
+    }
+  }
+}
+
+@media (max-width: $breakpoint-sm) {
+  .product-card {
+    mat-card-content {
+      .price {
+        font-size: 1.1rem;
+      }
+
+      .title {
+        font-size: 0.9rem;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- update home page 10km grid to use `nearby-products-grid`
- display three product cards per row on home
- enlarge and adjust `product-card-small` styles for mobile
- tweak near distance grid for two larger cards

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce424788c8330a703d656913cfd0f