### PR TITLE
Make profile page responsive for mobile

### DIFF
--- a/src/app/features/profile/my-publishes/my-publishes.component.scss
+++ b/src/app/features/profile/my-publishes/my-publishes.component.scss
@@ -118,3 +118,39 @@
     margin-top: 8px;
   }
 }
+
+@media (max-width: 768px) {
+  .publishes-header {
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+
+    .search-field {
+      width: 100%;
+    }
+  }
+
+  .board {
+    padding: 24px;
+  }
+
+  .board-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .board-actions {
+    width: 100%;
+    justify-content: space-between;
+
+    button {
+      width: 100%;
+    }
+  }
+}

--- a/src/app/features/profile/my-publishes/publish-card/publication-card.component.scss
+++ b/src/app/features/profile/my-publishes/publish-card/publication-card.component.scss
@@ -182,3 +182,30 @@
 :host ::ng-deep mat-checkbox.inner-check .mdc-checkbox__background {
   transform: scale(1.5);
 }
+
+@media (max-width: 768px) {
+  .card-inner {
+    flex-direction: column;
+    padding: 24px;
+  }
+
+  .left-card,
+  .right-card {
+    flex: 1 1 100%;
+  }
+
+  .left-card {
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+
+    .thumbnail {
+      width: 180px;
+      height: 180px;
+    }
+  }
+
+  .right-card {
+    margin-top: 16px;
+  }
+}

--- a/src/app/features/profile/profile-info/profile-info.component.scss
+++ b/src/app/features/profile/profile-info/profile-info.component.scss
@@ -83,3 +83,49 @@
     line-height: 2.5rem;
   }
 }
+
+@media (max-width: 768px) {
+  .prof-main {
+    padding: 60px 8%;
+    gap: 40px;
+  }
+
+  .section-title {
+    font-size: 2rem;
+
+    mat-icon {
+      font-size: 3rem;
+      height: 50px;
+      width: 50px;
+    }
+  }
+
+  .profile-wrapper p {
+    font-size: 1rem;
+  }
+
+  .info-container {
+    flex-direction: column;
+  }
+
+  .info-card {
+    width: 100%;
+    height: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .prof-main {
+    padding: 40px 5%;
+  }
+
+  .section-title {
+    font-size: 1.75rem;
+
+    mat-icon {
+      font-size: 2.5rem;
+      height: 40px;
+      width: 40px;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enhance profile-info with mobile breakpoints
- update my-publishes layout for small screens
- stack publication cards vertically on mobile

## Testing
- `npx ng build` *(fails: Inlining of fonts failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cebbb2db48330b0b84364a18be8f2