### PR TITLE
Disable residence action buttons during API call

### DIFF
--- a/src/app/features/profile/residence-verification/residence-verification.component.html
+++ b/src/app/features/profile/residence-verification/residence-verification.component.html
@@ -62,7 +62,7 @@
             <button
               mat-raised-button
               color="primary"
-              [disabled]="decisionLoading?.id === p.id"
+              [disabled]="!!decisionLoading"
               (click)="handleDecision(p, true)"
             >
               <mat-spinner *ngIf="decisionLoading?.id === p.id && decisionLoading?.approved" diameter="20"></mat-spinner>
@@ -71,7 +71,7 @@
             <button
               mat-raised-button
               color="warn"
-              [disabled]="decisionLoading?.id === p.id"
+              [disabled]="!!decisionLoading"
               (click)="handleDecision(p, false)"
             >
               <mat-spinner *ngIf="decisionLoading?.id === p.id && !decisionLoading?.approved" diameter="20"></mat-spinner>


### PR DESCRIPTION
## Summary
- disable approval buttons when a residence decision is pending

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0a195e5c8330b0f4c918dacea73e