### PR TITLE
feat: adjust home padding for responsive layout

### DIFF
--- a/src/app/features/home/components/home/home.component.scss
+++ b/src/app/features/home/components/home/home.component.scss
@@ -60,21 +60,19 @@ app-product-card-small {
   font-weight: 600;
   color: $primary-navy;
   margin: 0;
+  padding: 3rem 0;
+  background-color: #dfe0d5; // Cambiar a #dfe0d5
+
   @media (max-width: 1200px) {
     font-size: 1.75rem;
   }
   @media (max-width: 768px) {
     font-size: 1.2rem;
+    padding: 1.5rem 0;
   }
   @media (max-width: 600px) {
     font-size: 1.05rem;
   }
-  background-color: #dfe0d5; // Cambiar a #dfe0d5
-
-  @media (max-width: 768px) {
-    padding: 1.5rem 0;
-  }
-
   @media (max-width: 480px) {
     padding: 1rem 0;
   }


### PR DESCRIPTION
## Summary
- increase default home section padding for spacious layout
- keep reduced padding on smaller screens for responsiveness

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d7628847083309ba3c170ae25f64c