### PR TITLE
feat: add form validation

### DIFF
--- a/src/app/features/auth/components/register/register.component.html
+++ b/src/app/features/auth/components/register/register.component.html
@@ -22,12 +22,14 @@
           <app-form-field
             label="Nombre"
             formControlName="name"
+            [maxLength]="50"
             [hasError]="hasError('name')"
             [errorMessage]="getError('name')"
           />
           <app-form-field
             label="Apellido"
             formControlName="lastname"
+            [maxLength]="50"
             [hasError]="hasError('lastname')"
             [errorMessage]="getError('lastname')"
           />
@@ -39,6 +41,7 @@
             type="email"
             formControlName="email"
             placeholder="ejemplo@correo.com"
+            [maxLength]="100"
             [hasError]="hasError('email')"
             [errorMessage]="getError('email')"
           />
@@ -56,23 +59,25 @@
           />
         </div>
 
-        <app-form-field
-          label="DNI"
-          formControlName="dni"
-          type="text"
-          placeholder="Sin puntos ni guiones"
-          [hasError]="hasError('dni')"
-          [errorMessage]="getError('dni')"
-        />
+          <app-form-field
+            label="DNI"
+            formControlName="dni"
+            type="text"
+            placeholder="Sin puntos ni guiones"
+            [maxLength]="9"
+            [hasError]="hasError('dni')"
+            [errorMessage]="getError('dni')"
+          />
 
-        <app-form-field
-          label="Número de teléfono (opcional)"
-          type="tel"
-          formControlName="phone"
-          placeholder="+54 11 1234-5678"
-          [hasError]="hasError('phone')!"
-          [errorMessage]="getError('phone')"
-        />
+          <app-form-field
+            label="Número de teléfono (opcional)"
+            type="tel"
+            formControlName="phone"
+            placeholder="+54 11 1234-5678"
+            [maxLength]="20"
+            [hasError]="hasError('phone')!"
+            [errorMessage]="getError('phone')"
+          />
 
         <!-- selector de barrio -->
 
@@ -84,6 +89,7 @@
             formControlName="password"
             [showPasswordToggle]="true"
             (passwordToggle)="hidePassword = !hidePassword"
+            [maxLength]="50"
             [hasError]="hasError('password')"
             [errorMessage]="getError('password')"
           />
@@ -93,6 +99,7 @@
             formControlName="confirmPassword"
             [showPasswordToggle]="true"
             (passwordToggle)="hidePassword = !hidePassword"
+            [maxLength]="50"
             [hasError]="hasError('confirmPassword')"
             [errorMessage]="
               registerForm.hasError('mismatch') &&

--- a/src/app/features/auth/components/register/register.component.ts
+++ b/src/app/features/auth/components/register/register.component.ts
@@ -60,16 +60,43 @@ export class RegisterComponent {
      Formulario
      ----------------------------------------------------------- */
 
+  private readonly passwordPattern =
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+
   registerForm: FormGroup = this.fb.group(
     {
-      name: ["", [Validators.required, Validators.minLength(2)]],
-      lastname: ["", [Validators.required, Validators.minLength(2)]],
-      dni: ["", [Validators.required, Validators.pattern(/^\d{7,9}$/)]],
-      email: ["", [Validators.required, Validators.email]],
-      phone: [""],
+      name: [
+        "",
+        [Validators.required, Validators.minLength(2), Validators.maxLength(50)],
+      ],
+      lastname: [
+        "",
+        [Validators.required, Validators.minLength(2), Validators.maxLength(50)],
+      ],
+      dni: [
+        "",
+        [
+          Validators.required,
+          Validators.pattern(/^\d{7,9}$/),
+          Validators.maxLength(9),
+        ],
+      ],
+      email: [
+        "",
+        [Validators.required, Validators.email, Validators.maxLength(100)],
+      ],
+      phone: ["", [Validators.maxLength(20)]],
       countryId: [null, Validators.required],
-      password: ["", [Validators.required, Validators.minLength(6)]],
-      confirmPassword: ["", Validators.required],
+      password: [
+        "",
+        [
+          Validators.required,
+          Validators.minLength(8),
+          Validators.maxLength(50),
+          Validators.pattern(this.passwordPattern),
+        ],
+      ],
+      confirmPassword: ["", [Validators.required, Validators.maxLength(50)]],
       acceptTerms: [false, Validators.requiredTrue],
     },
     { validators: this.passwordsMatch }
@@ -191,10 +218,19 @@ export class RegisterComponent {
         c.errors!["minlength"].requiredLength
       } caracteres`;
     }
+    if (c.hasError("maxlength")) {
+      return `El campo ${this.label(field)} debe tener como máximo ${
+        c.errors!["maxlength"].requiredLength
+      } caracteres`;
+    }
     if (this.registerForm.hasError("mismatch") && field === "confirmPassword") {
       return "Las contraseñas no coinciden";
     }
-    if (c.hasError("pattern") && field === "dni") return "DNI inválido";
+    if (c.hasError("pattern")) {
+      if (field === "dni") return "DNI inválido";
+      if (field === "password")
+        return "Debe incluir mayúscula, minúscula, número y símbolo";
+    }
     return "";
   }
 

--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
@@ -12,10 +12,11 @@
         formControlName="title"
         [placeholder]="'Ingrese el título'"
         [label]="'Título'"
+        [maxLength]="100"
         [hasError]="
           leftForm.get('title')!.invalid && leftForm.get('title')!.touched
         "
-        [errorMessage]="'Título requerido (min 3)'"
+        [errorMessage]="'Título requerido (3-100)'"
       >
       </app-form-field>
 
@@ -90,11 +91,12 @@
         [rows]="5"
         [label]="'Descripción'"
         [placeholder]="'Contá con detalle tu producto'"
+        [maxLength]="1000"
         [hasError]="
           rightForm.get('description')!.invalid &&
           rightForm.get('description')!.touched
         "
-        [errorMessage]="'Descripción requerida'"
+        [errorMessage]="'Descripción requerida (10-1000)'"
       >
       </app-form-field>
 

--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
@@ -151,21 +151,28 @@ export class EditPublicationComponent implements OnInit {
 
     /* ▸ Formularios */
     this.leftForm = this.fb.group({
-      title    : [this.listing.title,
-                  [Validators.required, Validators.minLength(3)]],
-      price    : [this.listing.price,
-                  [Validators.required, Validators.min(1)]],
+      title: [
+        this.listing.title,
+        [Validators.required, Validators.minLength(3), Validators.maxLength(100)],
+      ],
+      price: [
+        this.listing.price,
+        [Validators.required, Validators.min(1)],
+      ],
       condition: [this.listing.condition, Validators.required],
-      images   : [this.selectedImages, minImages],
+      images: [this.selectedImages, minImages],
     });
 
     this.rightForm = this.fb.group({
-      description : [this.listing.description, Validators.required],
-      categories  : [[], Validators.minLength(1)],
-      paysCash    : [this.listing.acceptsCash],
-      paysCard    : [this.listing.acceptsCard],
-      paysTransf  : [this.listing.acceptsTransfer],
-      paysBarter  : [this.listing.acceptsBarter],
+      description: [
+        this.listing.description,
+        [Validators.required, Validators.minLength(10), Validators.maxLength(1000)],
+      ],
+      categories: [[], Validators.minLength(1)],
+      paysCash: [this.listing.acceptsCash],
+      paysCard: [this.listing.acceptsCard],
+      paysTransf: [this.listing.acceptsTransfer],
+      paysBarter: [this.listing.acceptsBarter],
     });
 
     this.rightForm.get("categories")!.setValue(

--- a/src/app/features/publish/components/publish/publish.component.html
+++ b/src/app/features/publish/components/publish/publish.component.html
@@ -38,6 +38,7 @@
             placeholder="Ej: Sillón de 3 cuerpos de cuero"
             formControlName="title"
             [disabled]="cardDisabled(0)"
+            [maxLength]="100"
             [hasError]="hasError('details', 'title')"
             [errorMessage]="getError('details', 'title')"
           >
@@ -100,6 +101,7 @@
             [disabled]="cardDisabled(2)"
             placeholder="Características, medidas, etc."
             formControlName="description"
+            [maxLength]="1000"
             [hasError]="hasError('details', 'description')"
             [errorMessage]="getError('details', 'description')"
           >

--- a/src/app/features/publish/components/publish/publish.component.ts
+++ b/src/app/features/publish/components/publish/publish.component.ts
@@ -107,8 +107,18 @@ export class PublishComponent implements OnInit {
 
   ngOnInit(): void {
     this.detailsForm = this.fb.group({
-      title: ["", [Validators.required, Validators.minLength(3)]],
-      description: ["", [Validators.required, Validators.minLength(10)]],
+      title: [
+        "",
+        [Validators.required, Validators.minLength(3), Validators.maxLength(100)],
+      ],
+      description: [
+        "",
+        [
+          Validators.required,
+          Validators.minLength(10),
+          Validators.maxLength(1000),
+        ],
+      ],
       condition: [2, Validators.required],
       images: [[], Validators.required],
     });
@@ -139,6 +149,10 @@ export class PublishComponent implements OnInit {
     if (c.hasError("minlength"))
       return `Debe tener al menos ${
         c.errors!["minlength"].requiredLength
+      } caracteres`;
+    if (c.hasError("maxlength"))
+      return `Debe tener como máximo ${
+        c.errors!["maxlength"].requiredLength
       } caracteres`;
     if (c.hasError("min")) return "Debe ser mayor que cero";
     if (c.hasError("pattern")) return "Formato inválido";


### PR DESCRIPTION
## Summary
- enforce max lengths and new password rules on registration form
- apply max length validation to product publish form
- add text length validation for editing publications

## Testing
- `npm test` (fails: Missing script "test")
- `npx ng test --watch=false` (fails: Unknown argument: watch)
- `npx ng lint` (fails: Cannot find "lint" target)


------
https://chatgpt.com/codex/tasks/task_e_688d767138008330b58fbe83d439b689