### PR TITLE
fix: limit image uploads to 5

### DIFF
--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
@@ -191,7 +191,9 @@ export class EditPublicationComponent implements OnInit {
   }
 
   addImages(evt: Event): void {
-    const files = Array.from((evt.target as HTMLInputElement).files ?? []);
+    const input = evt.target as HTMLInputElement;
+    const remaining = this.maxImages - this.filledImages;
+    const files = Array.from(input.files ?? []).slice(0, remaining);
     this.clearImageError();
 
     files.forEach(file => {
@@ -223,7 +225,7 @@ export class EditPublicationComponent implements OnInit {
       reader.readAsDataURL(file);
     });
 
-    (evt.target as HTMLInputElement).value = "";
+    input.value = "";
   }
 
   removeImage(i: number): void {

--- a/src/app/features/publish/components/publish/publish.component.ts
+++ b/src/app/features/publish/components/publish/publish.component.ts
@@ -260,7 +260,8 @@ export class PublishComponent implements OnInit {
     const input = event.target as HTMLInputElement;
     if (!input.files) return;
 
-    const files = Array.from(input.files);
+    const remaining = this.maxImages - this.selectedImages.length;
+    const files = Array.from(input.files).slice(0, remaining);
 
     files.forEach((file) => {
       if (this.selectedImages.length >= this.maxImages) return;


### PR DESCRIPTION
## Summary
- enforce max of five images in publish form
- restrict edit publication form to accept only five images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npx next@latest lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_688d726d92ac8330acfcd08949fe7a31