### PR TITLE
Renombrar 'Cerrar cuenta' a 'Borrar cuenta' en el footer

### DIFF
--- a/src/app/shared/components/footer/footer.component.html
+++ b/src/app/shared/components/footer/footer.component.html
@@ -41,7 +41,7 @@
             <li><a role="button" (click)="openContact()">Contacto</a></li>
             <li><a role="button" (click)="openTerms()">Terminos y condiciones</a></li>
             <li><a>Politica de seguridad</a></li>
-            <li><a role="button" (click)="openDelete()">Cerrar cuenta</a></li>
+            <li><a role="button" (click)="openDelete()">Borrar cuenta</a></li>
           </ul>
         </nav>
       </div>
@@ -80,12 +80,12 @@
 <!-- Delete Account Modal -->
 <app-default-modal
   *ngIf="deleteOpen"
-  title="¿Cerrar cuenta?"
+  title="¿Borrar cuenta?"
   [buttons]="deleteButtons"
   (close)="deleteOpen = false"
 >
   <p>
-    ¿Estás seguro de que deseas cerrar tu cuenta? Esta acción no se puede
+    ¿Estás seguro de que deseas borrar tu cuenta? Esta acción no se puede
     deshacer.
   </p>
 </app-default-modal>


### PR DESCRIPTION
## Summary
- Renombra 'Cerrar cuenta' a 'Borrar cuenta' en el enlace del footer y en el modal de eliminación

## Testing
- `npm test` (missing script)
- `npm run lint` (failed: sh: 1: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_688d76a2d9f8833084d385183412f912