### PR TITLE
Fix auth card layout on mobile

### DIFF
--- a/src/app/features/auth/components/auth-card/auth-card.component.scss
+++ b/src/app/features/auth/components/auth-card/auth-card.component.scss
@@ -84,17 +84,6 @@ footer {
   }
 }
 
-@media (max-width: 600px) {
-  footer {
-    button {
-      min-width: 120px;
-      max-width: 200px;
-      font-size: 0.95rem;
-      padding: 8px 8px;
-      height: 36px;
-    }
-  }
-}
 /* ---------- Links ---------- */
 .links {
   display: flex;
@@ -127,7 +116,7 @@ footer {
     padding: 2px 0 0 0;
   }
   .auth-wrapper {
-    max-width: 100vw;
+    max-width: 100% !important;
     gap: 6px;
   }
   .auth-header h1 {
@@ -154,17 +143,17 @@ footer {
     border-radius: 5px;
   }
   footer {
-    flex-direction: row;
+    flex-direction: column;
     gap: 4px;
+    align-items: stretch;
     button {
-      min-width: 90vw;
-      max-width: 98vw;
-      width: 98vw;
+      width: 100%;
+      min-width: 0;
+      max-width: none;
       font-size: 0.93rem;
       padding: 8px 0;
       height: 32px;
-      margin-left: -2vw;
-      margin-right: -2vw;
+      margin: 0;
       box-sizing: border-box;
       border-radius: 6px;
     }


### PR DESCRIPTION
## Summary
- Ensure auth card takes full width on small screens
- Stack action buttons vertically and remove overflow on mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d76c8f2c483309dad3314c56736fc