### PR TITLE
feat: persist search filters

### DIFF
--- a/src/app/features/search/search-filters/search-filters.component.ts
+++ b/src/app/features/search/search-filters/search-filters.component.ts
@@ -156,5 +156,6 @@ export class SearchFiltersComponent implements OnInit {
 
   reset() {
     this.form.reset();
+    this.clear.emit();
   }
 }

--- a/src/app/shared/services/filter.service.ts
+++ b/src/app/shared/services/filter.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { ListListingsRequestDto } from '../models/listing.model';
+
+@Injectable({ providedIn: 'root' })
+export class FilterService {
+  private readonly STORAGE_KEY = 'searchFilters';
+  private readonly filtersSubject = new BehaviorSubject<Partial<ListListingsRequestDto>>({});
+
+  constructor() {
+    try {
+      const raw = localStorage.getItem(this.STORAGE_KEY);
+      if (raw) {
+        this.filtersSubject.next(JSON.parse(raw));
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  get value(): Partial<ListListingsRequestDto> {
+    return this.filtersSubject.value;
+  }
+
+  get filters$(): Observable<Partial<ListListingsRequestDto>> {
+    return this.filtersSubject.asObservable();
+  }
+
+  set(filters: Partial<ListListingsRequestDto>): void {
+    this.filtersSubject.next(filters);
+    try {
+      localStorage.setItem(this.STORAGE_KEY, JSON.stringify(filters));
+    } catch {
+      // ignore storage errors
+    }
+  }
+
+  clear(): void {
+    this.filtersSubject.next({});
+    try {
+      localStorage.removeItem(this.STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `FilterService` to persist search filters with localStorage
- keep header and search views in sync with saved filters
- emit `clear` event from filter form reset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890e9f122808330b4eaf5ada3dc187d