### PR TITLE
Disable publish when price invalid in step 3

### DIFF
--- a/src/app/features/publish/components/publish/publish.component.html
+++ b/src/app/features/publish/components/publish/publish.component.html
@@ -238,7 +238,7 @@
             placeholder="0"
             prefixIcon="$"
             formControlName="price"
-            [hasError]="hasError('commercial', 'price')"
+            [hasError]="!!commercialForm.get('price')?.invalid"
             [errorMessage]="getError('commercial', 'price')"
           >
           </app-form-field>
@@ -281,7 +281,7 @@
             color="accent"
             class="publish-button"
             type="submit"
-            [disabled]="isLoading"
+            [disabled]="isLoading || !!commercialForm.get('price')?.invalid"
           >
             <ng-container *ngIf="!isLoading; else loading">
               Publicar


### PR DESCRIPTION
## Summary
- Deshabilita el botón *Publicar* en el paso 3 cuando el precio es inválido y lo deja en gris
- Muestra el mensaje de error del precio si hay un problema de validación

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run lint` *(falla: sh: 1: next: not found)*
- `npx ng lint` *(falla: Cannot find "lint" target for the specified project)*
- `npx ng build` *(falla: Inlining of fonts failed. https://fonts.googleapis.com/... status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6890f6c3e5a883308be67ca70530aa08