### PR TITLE
fix: reset filters and avoid duplicate listings

### DIFF
--- a/src/app/features/home/components/home/home.component.ts
+++ b/src/app/features/home/components/home/home.component.ts
@@ -9,6 +9,7 @@ import { MatProgressSpinnerModule } from "@angular/material/progress-spinner";
 import { SEOService } from "../../../../shared/services/seo.service";
 import { ListingService } from "../../../../shared/services/listing.service";
 import { CategoryService } from "../../../../shared/services/category.service";
+import { FilterService } from "../../../../shared/services/filter.service";
 import { ListingResponseDto } from "../../../../shared/models/listing.model";
 import { Category } from "../../../../shared/models/category.model";
 import { HeaderComponent } from "src/app/shared/components/header/header.component";
@@ -52,10 +53,12 @@ export class HomeComponent implements OnInit {
   constructor(
     private seoService: SEOService,
     private listingSrv: ListingService,
-    private categorySrv: CategoryService
+    private categorySrv: CategoryService,
+    private filterSrv: FilterService
   ) {}
 
   ngOnInit() {
+    this.filterSrv.clear();
     this.setupSEO();
     this.loadData();
   }

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -5,7 +5,6 @@ import {
   ViewChild,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
-  HostListener,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from "@angular/router";
@@ -355,13 +354,5 @@ export class SearchComponent implements OnInit {
     this.current.categoryIds = this.categoriesSlots
       .filter((c) => c.idPath)
       .map((c) => c.idPath);
-  }
-
-  @HostListener("window:keydown.enter", ["$event"])
-  onEnterKey(event: KeyboardEvent) {
-    // Evita que cualquier formulario de dentro haga un submit nativo
-    event.preventDefault();
-    // Llama al mismo apply que si viniera del drawer
-    this.onApplyFilters(this.current);
   }
 }

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -194,31 +194,18 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   onSearch(): void {
+    const term = this.searchQuery.trim();
     const params: any = {};
-    const saved = { ...this.filterSrv.value };
 
-    if (this.searchQuery.trim()) {
-      params.searchTerm = this.searchQuery.trim();
-      saved.searchTerm = params.searchTerm;
-    } else {
-      delete saved.searchTerm;
-    }
-    if (this.selectedCategoryId) {
-      params.categoryIds = [this.selectedCategoryId];
-      saved.categoryIds = [this.selectedCategoryId];
-    } else if (this.selectedCategoryLabel !== "Todas") {
-      const cat = this.categories.find(
-        (c) => c.name === this.selectedCategoryLabel
-      );
-      if (cat) {
-        params.categoryIds = [cat.id];
-        saved.categoryIds = [cat.id];
-      }
-    } else {
-      delete saved.categoryIds;
+    this.filterSrv.clear();
+    this.selectedCategoryLabel = "Todas";
+    this.selectedCategoryId = null;
+
+    if (term) {
+      params.searchTerm = term;
+      this.filterSrv.set({ searchTerm: term });
     }
 
-    this.filterSrv.set(saved);
     this.router.navigate(["/search"], { queryParams: params });
   }
 


### PR DESCRIPTION
## Summary
- avoid double `listListings` calls by removing extra Enter key listener
- clear stored filters when navigating back to home
- header quick search now sets only the text filter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install next@latest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890f81a1bf08330acbd87408240e37e