### PR TITLE
fix: limit enter key search to search page

### DIFF
--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -262,6 +262,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   @HostListener('window:keydown.enter', ['$event'])
   onEnter(event: KeyboardEvent): void {
+    if (!this.router.url.startsWith('/search')) {
+      return;
+    }
+
     if (
       this.searchInputRef &&
       document.activeElement === this.searchInputRef.nativeElement


### PR DESCRIPTION
## Summary
- only trigger header search on Enter when on `/search`

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891553f68dc8330895e540685832aab