### PR TITLE
Validate whitespace-only fields

### DIFF
--- a/src/app/features/auth/components/register/register.component.ts
+++ b/src/app/features/auth/components/register/register.component.ts
@@ -5,6 +5,7 @@ import {
   AbstractControl,
   FormGroup,
   ReactiveFormsModule,
+  ValidatorFn,
 } from "@angular/forms";
 import { Router } from "@angular/router";
 import { MatSnackBar } from "@angular/material/snack-bar";
@@ -50,6 +51,13 @@ import { RegistrationDataService } from "src/app/shared/services/registration-da
   styleUrls: ["./register.component.scss", "../../auth-styles.scss"],
 })
 export class RegisterComponent {
+  private notBlank: ValidatorFn = (control: AbstractControl) => {
+    const value = control.value as string;
+    return typeof value === "string" && value.trim().length === 0 && value.length > 0
+      ? { required: true }
+      : null;
+  };
+
   private passwordsMatch = (group: AbstractControl) => {
     const pass = group.get("password")?.value;
     const confirm = group.get("confirmPassword")?.value;
@@ -67,23 +75,39 @@ export class RegisterComponent {
     {
       name: [
         "",
-        [Validators.required, Validators.minLength(2), Validators.maxLength(50)],
+        [
+          Validators.required,
+          this.notBlank,
+          Validators.minLength(2),
+          Validators.maxLength(50),
+        ],
       ],
       lastname: [
         "",
-        [Validators.required, Validators.minLength(2), Validators.maxLength(50)],
+        [
+          Validators.required,
+          this.notBlank,
+          Validators.minLength(2),
+          Validators.maxLength(50),
+        ],
       ],
       dni: [
         "",
         [
           Validators.required,
+          this.notBlank,
           Validators.pattern(/^\d{7,9}$/),
           Validators.maxLength(9),
         ],
       ],
       email: [
         "",
-        [Validators.required, Validators.email, Validators.maxLength(100)],
+        [
+          Validators.required,
+          this.notBlank,
+          Validators.email,
+          Validators.maxLength(100),
+        ],
       ],
       phone: ["", [Validators.maxLength(20)]],
       countryId: [null, Validators.required],
@@ -91,12 +115,16 @@ export class RegisterComponent {
         "",
         [
           Validators.required,
+          this.notBlank,
           Validators.minLength(8),
           Validators.maxLength(50),
           Validators.pattern(this.passwordPattern),
         ],
       ],
-      confirmPassword: ["", [Validators.required, Validators.maxLength(50)]],
+      confirmPassword: [
+        "",
+        [Validators.required, this.notBlank, Validators.maxLength(50)],
+      ],
       acceptTerms: [false, Validators.requiredTrue],
     },
     { validators: this.passwordsMatch }

--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
@@ -70,6 +70,13 @@ export class EditPublicationComponent implements OnInit {
   leftForm!: FormGroup;
   rightForm!: FormGroup;
 
+  private notBlank: ValidatorFn = (control: AbstractControl) => {
+    const value = control.value as string;
+    return typeof value === "string" && value.trim().length === 0 && value.length > 0
+      ? { required: true }
+      : null;
+  };
+
   /* ---------- categorías ----------------------------------- */
   categories: { idPath: string; name: string }[] = [];
   showList: boolean[] = [];
@@ -159,6 +166,7 @@ export class EditPublicationComponent implements OnInit {
         this.listing.title,
         [
           Validators.required,
+          this.notBlank,
           Validators.minLength(3),
           Validators.maxLength(100),
         ],
@@ -173,6 +181,7 @@ export class EditPublicationComponent implements OnInit {
         this.listing.description,
         [
           Validators.required,
+          this.notBlank,
           Validators.minLength(10),
           Validators.maxLength(1000),
         ],

--- a/src/app/features/publish/components/publish/publish.component.ts
+++ b/src/app/features/publish/components/publish/publish.component.ts
@@ -13,6 +13,7 @@ import {
   Validators,
   ReactiveFormsModule,
   AbstractControl,
+  ValidatorFn,
 } from "@angular/forms";
 import { Router } from "@angular/router";
 import { MatSnackBar } from "@angular/material/snack-bar";
@@ -79,6 +80,13 @@ export class PublishComponent implements OnInit {
   detailsForm!: FormGroup;
   commercialForm!: FormGroup;
 
+  private notBlank: ValidatorFn = (control: AbstractControl) => {
+    const value = control.value as string;
+    return typeof value === "string" && value.trim().length === 0 && value.length > 0
+      ? { required: true }
+      : null;
+  };
+
   categories: CategorySelection[] = [];
   showList: boolean[] = [];
 
@@ -109,12 +117,18 @@ export class PublishComponent implements OnInit {
     this.detailsForm = this.fb.group({
       title: [
         "",
-        [Validators.required, Validators.minLength(3), Validators.maxLength(100)],
+        [
+          Validators.required,
+          this.notBlank,
+          Validators.minLength(3),
+          Validators.maxLength(100),
+        ],
       ],
       description: [
         "",
         [
           Validators.required,
+          this.notBlank,
           Validators.minLength(10),
           Validators.maxLength(1000),
         ],


### PR DESCRIPTION
## Summary
- ensure registration form rejects fields made only of spaces
- prevent whitespace-only titles and descriptions when publishing or editing listings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892253ad7fc8330a3a8f6d71dafe291