### PR TITLE
fix: format search term display

### DIFF
--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -25,7 +25,7 @@
         </button>
         <mat-icon>search</mat-icon>
         <h1>
-          Búsqueda<b *ngIf="current.searchTerm">": {{ current.searchTerm }}"</b>
+          Búsqueda<b *ngIf="current.searchTerm">: "{{ current.searchTerm }}"</b>
         </h1>
       </div>
 


### PR DESCRIPTION
## Summary
- fix search term header to show colon before quotes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68923f216b888330a53b82243f62a972