### PR TITLE
feat: validate non-empty price when editing

### DIFF
--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
@@ -74,7 +74,7 @@
         [hasError]="
           leftForm.get('price')!.invalid && leftForm.get('price')!.touched
         "
-        [errorMessage]="'Precio > 0'"
+        [errorMessage]="'Precio requerido (> 0)'"
         class="price-field"
       >
       </app-form-field>

--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
@@ -171,7 +171,10 @@ export class EditPublicationComponent implements OnInit {
           Validators.maxLength(100),
         ],
       ],
-      price: [this.listing.price, [Validators.required, Validators.min(1)]],
+      price: [
+        this.listing.price,
+        [Validators.required, this.notBlank, Validators.min(1)],
+      ],
       condition: [this.listing.condition, Validators.required],
       images: [this.selectedImages, minImages],
     });


### PR DESCRIPTION
## Summary
- ensure price isn't blank when editing publications
- clarify error message for empty price

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npx ng lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_6892c2ded1b08330b6da8953cf4ab925