### PR TITLE
feat: set spanish date format

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,14 +3,19 @@ import { bootstrapApplication } from "@angular/platform-browser";
 import { provideRouter, withRouterConfig } from "@angular/router";
 import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { provideHttpClient, withInterceptors } from "@angular/common/http";
-import { importProvidersFrom } from "@angular/core";
+import { importProvidersFrom, LOCALE_ID } from "@angular/core";
 import { BrowserModule, Title, Meta } from "@angular/platform-browser";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { MAT_DATE_LOCALE } from "@angular/material/core";
+import { registerLocaleData } from "@angular/common";
+import localeEsAr from "@angular/common/locales/es-AR";
 
 import { AppComponent } from "./app/app.component";
 import { routes } from "./app/app.routes";
 import { authInterceptor } from "./app/core/interceptors/auth.interceptor";
 import { errorInterceptor } from "./app/core/interceptors/error.interceptor";
+
+registerLocaleData(localeEsAr);
 
 bootstrapApplication(AppComponent, {
   providers: [
@@ -27,5 +32,7 @@ bootstrapApplication(AppComponent, {
     // 4) Servicios de título/meta
     Title,
     Meta,
+    { provide: LOCALE_ID, useValue: "es-AR" },
+    { provide: MAT_DATE_LOCALE, useValue: "es-AR" },
   ],
 }).catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- register Argentinian Spanish locale
- use Spanish locale for Angular and Material date handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a67fa2108330b0275071f367af06