### PR TITLE
Hide header filter bar on search page

### DIFF
--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -1,4 +1,4 @@
-<app-header></app-header>
+<app-header [showCategoryNav]="false"></app-header>
 
 <mat-sidenav-container class="search-container">
   <!-- Drawer móvil -->

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -1,7 +1,7 @@
 <div class="header-toolbar">
   <div
     class="header-container"
-    [ngClass]="{ 'header-one-row': !logged || publishing }"
+    [ngClass]="{ 'header-one-row': !logged || publishing || !showCategoryNav }"
   >
     <!-- Logo y ubicación -->
     <div class="header-left">
@@ -105,7 +105,7 @@
 
     <!-- Botón menú móvil -->
     <button
-      *ngIf="logged && !publishing"
+      *ngIf="logged && !publishing && showCategoryNav"
       mat-icon-button
       class="mobile-menu-toggle"
       (click)="toggleMobileMenu()"
@@ -120,7 +120,7 @@
 <div
   class="category-nav"
   aria-label="Navegación de categorías"
-  *ngIf="logged && !publishing"
+  *ngIf="logged && !publishing && showCategoryNav"
   [ngClass]="{ 'mobile-open': isMobileMenuOpen }"
 >
   <div class="nav-container">

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -79,6 +79,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   @Input() logged = true;
   @Input() publishing = false;
+  @Input() showCategoryNav = true;
 
   sortOrder: "ASC" | "DESC" = "DESC";
 


### PR DESCRIPTION
## Summary
- add `showCategoryNav` input to header to toggle secondary navigation
- use new flag on search page so only the top header bar with search and categories is shown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found; installing `next` failed with dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6a1a8208330963dd44e7db642a3