### PR TITLE
fix: adjust search filter button positioning

### DIFF
--- a/src/app/features/search/search-filters/search-filters.component.html
+++ b/src/app/features/search/search-filters/search-filters.component.html
@@ -1,4 +1,12 @@
 <form class="filters-form" [formGroup]="form" (keydown.enter)="emitFilters()">
+  <button
+    mat-button
+    type="button"
+    class="clear-btn"
+    (click)="reset()"
+  >
+    Limpiar
+  </button>
   <!-- Buscar -->
   <app-form-field
     type="text"
@@ -145,6 +153,5 @@
     >
       Filtrar
     </button>
-    <button mat-button type="button" (click)="reset()">Limpiar</button>
   </div>
 </form>

--- a/src/app/features/search/search-filters/search-filters.component.scss
+++ b/src/app/features/search/search-filters/search-filters.component.scss
@@ -1,6 +1,7 @@
 @import '../../../../shared/styles/variables';
 
 .filters-form {
+  position: relative;
   width: 360px;
   padding: 1.25rem;
   display: flex;
@@ -80,8 +81,18 @@
   }
 
   .actions {
+    position: sticky;
+    bottom: 0;
     display: flex;
     justify-content: flex-end;
     gap: 0.75rem;
+    padding-top: 0.5rem;
+    background: white;
+  }
+
+  .clear-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- keep filter action button fixed at panel bottom
- move clear button to top right of filter form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6df2d088330b1aef53d91d5776b