### PR TITLE
feat: validate dates in filters

### DIFF
--- a/src/app/features/search/search-filters/search-filters.component.html
+++ b/src/app/features/search/search-filters/search-filters.component.html
@@ -113,12 +113,16 @@
       label="Desde"
       placeholder="dd/mm/aaaa"
       formControlName="createdFrom"
+      [hasError]="form.get('createdFrom')!.hasError('invalidDate') && form.get('createdFrom')!.touched"
+      errorMessage="Fecha inválida"
     ></app-form-field>
     <app-form-field
       type="date"
       label="Hasta"
       placeholder="dd/mm/aaaa"
       formControlName="createdTo"
+      [hasError]="form.get('createdTo')!.hasError('invalidDate') && form.get('createdTo')!.touched"
+      errorMessage="Fecha inválida"
     ></app-form-field>
   </div>
 

--- a/src/app/features/search/search-filters/search-filters.component.ts
+++ b/src/app/features/search/search-filters/search-filters.component.ts
@@ -11,6 +11,8 @@ import { CommonModule } from "@angular/common";
 import {
   FormBuilder,
   FormGroup,
+  AbstractControl,
+  ValidationErrors,
   ReactiveFormsModule,
   Validators,
 } from "@angular/forms";
@@ -83,6 +85,13 @@ export class SearchFiltersComponent implements OnInit {
 
   constructor(private fb: FormBuilder, private countrySrv: CountryService) {}
 
+  private dateValidator(control: AbstractControl): ValidationErrors | null {
+    const value = control.value;
+    if (!value) return null;
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? { invalidDate: true } : null;
+  }
+
   private toInputDate(value?: string | null): string | null {
     if (!value) return null;
     const d = new Date(value);
@@ -116,8 +125,14 @@ export class SearchFiltersComponent implements OnInit {
         [Validators.min(1), Validators.pattern(/^\d+$/), Validators.max(99999999)],
       ],
       maxDistanceKm: [this.initialFilters.maxDistanceKm ?? null],
-      createdFrom: [this.toInputDate(this.initialFilters.createdFrom)],
-      createdTo: [this.toInputDate(this.initialFilters.createdTo)],
+      createdFrom: [
+        this.toInputDate(this.initialFilters.createdFrom),
+        this.dateValidator,
+      ],
+      createdTo: [
+        this.toInputDate(this.initialFilters.createdTo),
+        this.dateValidator,
+      ],
       acceptsCash: [this.initialFilters.acceptsCash ?? false],
       acceptsCard: [this.initialFilters.acceptsCard ?? false],
       acceptsTransfer: [this.initialFilters.acceptsTransfer ?? false],

--- a/src/app/shared/components/header/header.component.html
+++ b/src/app/shared/components/header/header.component.html
@@ -329,29 +329,35 @@
   <div class="menu-body" (click)="$event.stopPropagation()">
     <mat-form-field appearance="fill" class="w-100">
       <mat-label>Desde</mat-label>
-      <input matInput [matDatepicker]="pickerFrom" [(ngModel)]="filters.from" />
-      <mat-datepicker-toggle
-        matIconSuffix
-        [for]="pickerFrom"
-      ></mat-datepicker-toggle>
+      <input
+        matInput
+        [matDatepicker]="pickerFrom"
+        [(ngModel)]="filters.from"
+        #fromDate="ngModel"
+      />
+      <mat-datepicker-toggle matIconSuffix [for]="pickerFrom"></mat-datepicker-toggle>
       <mat-datepicker #pickerFrom></mat-datepicker>
+      <mat-error *ngIf="fromDate.invalid">Fecha inválida</mat-error>
     </mat-form-field>
 
     <mat-form-field appearance="fill" class="w-100">
       <mat-label>Hasta</mat-label>
-      <input matInput [matDatepicker]="pickerTo" [(ngModel)]="filters.to" />
-      <mat-datepicker-toggle
-        matIconSuffix
-        [for]="pickerTo"
-      ></mat-datepicker-toggle>
+      <input
+        matInput
+        [matDatepicker]="pickerTo"
+        [(ngModel)]="filters.to"
+        #toDate="ngModel"
+      />
+      <mat-datepicker-toggle matIconSuffix [for]="pickerTo"></mat-datepicker-toggle>
       <mat-datepicker #pickerTo></mat-datepicker>
+      <mat-error *ngIf="toDate.invalid">Fecha inválida</mat-error>
     </mat-form-field>
 
     <button
-      class="apply-button"
+      class="apply-button w-100"
       mat-stroked-button
       color="primary"
-      class="w-100"
+      [disabled]="fromDate.invalid || toDate.invalid"
       mat-menu-close
       (click)="applyFilters()"
     >


### PR DESCRIPTION
## Summary
- validate date inputs in advanced search filters
- show invalid date errors in search and header menus

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68940d75038c8330b0f0f0b87f3e4fb8