### PR TITLE
refactor: show product info instead of edit

### DIFF
--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
@@ -1,6 +1,6 @@
 <!-- edit-publication.component.html -->
 <app-default-modal
-  [title]="'Información sobre el producto'"
+  [title]="'Información de producto'"
   [buttons]="modalButtons"
   (close)="closed.emit()"
 >

--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
@@ -104,7 +104,7 @@ export class EditPublicationComponent implements OnInit {
   get modalButtons(): ModalButton[] {
     return [
       {
-        label: "Cancelar",
+        label: "Cerrar",
         type: "secondary",
         action: () => this.closed.emit(),
         disabled: this.saving,

--- a/src/app/features/profile/my-publishes/publish-card/publication-card.component.html
+++ b/src/app/features/profile/my-publishes/publish-card/publication-card.component.html
@@ -23,7 +23,7 @@
             class="edit"
             *ngIf="loadingSide !== 'left'"
             (click)="openEdit('left')"
-            >edit</mat-icon
+            >info</mat-icon
           >
           <mat-spinner *ngIf="loadingSide === 'left'" diameter="20"></mat-spinner>
         </div>
@@ -54,7 +54,7 @@
         class="edit"
         *ngIf="loadingSide !== 'right'"
         (click)="openEdit('right')"
-        >edit</mat-icon
+        >info</mat-icon
       >
       <mat-spinner *ngIf="loadingSide === 'right'" diameter="20"></mat-spinner>
     </div>


### PR DESCRIPTION
## Summary
- replace pencil edit icons with info icons for publication modals
- rename edit modal title to "Información de producto"
- change edit modal cancel button label to "Cerrar"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68940f9f31d8833085212af4142827c9