### PR TITLE
Validate numeric price input

### DIFF
--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
@@ -74,7 +74,7 @@
         [hasError]="
           leftForm.get('price')!.invalid && leftForm.get('price')!.touched
         "
-        [errorMessage]="'Precio requerido (> 0)'"
+        [errorMessage]="getPriceError()"
         class="price-field"
       >
       </app-form-field>

--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
@@ -123,6 +123,21 @@ export class EditPublicationComponent implements OnInit {
     ];
   }
 
+  getPriceError(): string {
+    const c = this.leftForm.get('price');
+    if (!c) return '';
+    if (c.hasError('required') || c.hasError('min')) {
+      return 'Precio requerido (> 0)';
+    }
+    if (c.hasError('max')) {
+      return 'El precio debe ser menor o igual a $99.999.999';
+    }
+    if (c.hasError('pattern')) {
+      return 'Formato inválido';
+    }
+    return '';
+  }
+
   /* ---------- ctor / init ---------------------------------- */
   constructor(private fb: FormBuilder) {}
 
@@ -173,7 +188,13 @@ export class EditPublicationComponent implements OnInit {
       ],
       price: [
         this.listing.price,
-        [Validators.required, this.notBlank, Validators.min(1)],
+        [
+          Validators.required,
+          this.notBlank,
+          Validators.min(1),
+          Validators.max(99999999),
+          Validators.pattern(/^\d+$/),
+        ],
       ],
       condition: [this.listing.condition, Validators.required],
       images: [this.selectedImages, minImages],

--- a/src/app/features/publish/components/publish/publish.component.ts
+++ b/src/app/features/publish/components/publish/publish.component.ts
@@ -141,7 +141,8 @@ export class PublishComponent implements OnInit {
       price: [null, [
         Validators.required,
         Validators.min(1),
-        Validators.max(99999999)
+        Validators.max(99999999),
+        Validators.pattern(/^\d+$/)
       ]],
       acceptsCash: [false],
       acceptsCard: [false],


### PR DESCRIPTION
## Summary
- ensure price field only accepts digits on new listings
- validate numeric price and show specific error during publication edits

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68940f5c80688330ad323d5a27083879