### PR TITLE
refactor: move filter button to search page

### DIFF
--- a/src/app/features/search/search-filters/search-filters.component.html
+++ b/src/app/features/search/search-filters/search-filters.component.html
@@ -141,16 +141,6 @@
   <!-- Acciones -->
   <div class="actions-bar">
     <button
-      mat-flat-button
-      color="primary"
-      [disabled]="form.invalid"
-      type="button"
-      (click)="emitFilters()"
-      class="filter-btn"
-    >
-      Filtrar
-    </button>
-    <button
       mat-button
       type="button"
       class="clear-btn"

--- a/src/app/features/search/search-filters/search-filters.component.scss
+++ b/src/app/features/search/search-filters/search-filters.component.scss
@@ -96,11 +96,4 @@
     right: 1.25rem;
     height: 20px;
   }
-
-  .filter-btn {
-    position: sticky;
-    bottom: 5rem;
-    right: 1.25rem;
-    height: 20px;
-  }
 }

--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -4,6 +4,7 @@
   <!-- Drawer móvil -->
   <mat-sidenav #drawer mode="over" class="filters-drawer">
     <app-search-filters
+      #mobileFilters
       [initialFilters]="current"
       (apply)="onApplyFilters($event)"
       (clear)="onClearFilters()"
@@ -38,6 +39,7 @@
         <!-- Sidebar desktop -->
         <aside class="filters-sidebar">
           <app-search-filters
+            #desktopFilters
             class="desktop-only"
             [initialFilters]="current"
             (apply)="onApplyFilters($event)"
@@ -119,6 +121,14 @@
         </div>
       </div>
     </main>
+    <button
+      mat-flat-button
+      color="primary"
+      class="sticky-filter-btn"
+      (click)="applyFilters()"
+    >
+      Filtrar
+    </button>
   </mat-sidenav-content>
 </mat-sidenav-container>
 

--- a/src/app/features/search/search.component.scss
+++ b/src/app/features/search/search.component.scss
@@ -144,3 +144,10 @@
     display: inline-flex;
   }
 }
+
+.sticky-filter-btn {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 30%;
+  z-index: 1000;
+}

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -73,6 +73,8 @@ export class SearchComponent implements OnInit {
   private navSub!: Subscription;
 
   @ViewChild("drawer") drawer: any;
+  @ViewChild("mobileFilters") mobileFilters?: SearchFiltersComponent;
+  @ViewChild("desktopFilters") desktopFilters?: SearchFiltersComponent;
   @Input() request: Partial<ListListingsRequestDto> = {};
   current: Partial<ListListingsRequestDto> = {};
 
@@ -209,6 +211,14 @@ export class SearchComponent implements OnInit {
 
   openFilters() {
     this.drawer?.open();
+  }
+
+  applyFilters() {
+    if (this.drawer?.opened) {
+      this.mobileFilters?.emitFilters();
+    } else {
+      this.desktopFilters?.emitFilters();
+    }
   }
 
   /* ========== orden ========== */


### PR DESCRIPTION
## Summary
- move filter action out of SearchFilters into Search
- add sticky Filtrar button at bottom of search screen
- wire up filter button to trigger appropriate filters

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_689413411414833097cafb726d80ee55