### PR TITLE
feat(search): persist applied filters

### DIFF
--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -195,6 +195,8 @@ export class SearchComponent implements OnInit {
     } else {
       delete this.current.centerCountryId;
     }
+    // Persistir los filtros aplicados
+    this.filterSrv.set(this.current);
 
     this.loadListings();
     this.drawer?.close();


### PR DESCRIPTION
## Summary
- persist search filters by saving them in FilterService when applied

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found; attempted install but dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_6894136faa588330bbb3eff5c06388cf