### PR TITLE
refactor: move filter button to filters component

### DIFF
--- a/src/app/features/search/search-filters/search-filters.component.html
+++ b/src/app/features/search/search-filters/search-filters.component.html
@@ -140,13 +140,16 @@
 
   <!-- Acciones -->
   <div class="actions-bar">
-    <button
-      mat-button
-      type="button"
-      class="clear-btn"
-      (click)="reset()"
-    >
+    <button mat-stroked-button type="button" (click)="reset()">
       Limpiar
+    </button>
+    <button
+      mat-flat-button
+      type="button"
+      class="apply-btn"
+      (click)="emitFilters()"
+    >
+      Filtrar
     </button>
   </div>
 </form>

--- a/src/app/features/search/search-filters/search-filters.component.scss
+++ b/src/app/features/search/search-filters/search-filters.component.scss
@@ -80,20 +80,18 @@
     }
   }
 
-  .actions {
-    position: sticky;
-    bottom: 0;
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.75rem;
-    padding-top: 0.5rem;
-    background: white;
-  }
+    .actions-bar {
+      position: sticky;
+      bottom: 0;
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      padding-top: 0.5rem;
+      background: white;
+    }
 
-  .clear-btn {
-    position: absolute;
-    top: 1.25rem;
-    right: 1.25rem;
-    height: 20px;
+    .apply-btn {
+      background-color: $primary-green;
+      color: $white;
+    }
   }
-}

--- a/src/app/features/search/search.component.html
+++ b/src/app/features/search/search.component.html
@@ -123,15 +123,6 @@
     </main>
   </mat-sidenav-content>
 
-  <button
-    mat-flat-button
-    color="primary"
-    class="sticky-filter-btn"
-    (click)="applyFilters()"
-  >
-    Filtrar
-  </button>
-  <div #stickTrigger class="stick-trigger" aria-hidden="true"></div>
 </mat-sidenav-container>
 
 <app-footer></app-footer>

--- a/src/app/features/search/search.component.scss
+++ b/src/app/features/search/search.component.scss
@@ -149,33 +149,3 @@
   }
 }
 
-.sticky-filter-btn {
-  position: static; /* ya no es fixed por defecto */
-  margin: 24px auto; /* margen en flujo normal */
-  /* ↓ resto de estilos sin cambios (color, tamaño, etc.) */
-  left: auto;
-  bottom: auto;
-  transform: none;
-}
-
-/* --- Variante fija cuando el sentinela entra en viewport --- */
-.sticky-filter-btn.is-fixed {
-  position: fixed;
-  left: 50%;
-  bottom: 32px;
-  transform: translateX(-50%);
-  margin: 0;
-  z-index: 1000;
-}
-
-/* Mobile tweaks (mantener lo que ya tenías) */
-@media (max-width: 600px) {
-  .sticky-filter-btn.is-fixed {
-    bottom: 16px;
-  }
-}
-
-/* (opcional) evita que el botón tape contenido cuando está fijo */
-.search-main {
-  padding-bottom: 88px; /* altura aprox. del botón */
-}

--- a/src/app/features/search/search.component.ts
+++ b/src/app/features/search/search.component.ts
@@ -6,7 +6,6 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   HostListener,
-  ElementRef,
 } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import {
@@ -131,7 +130,6 @@ export class SearchComponent implements OnInit {
 
   ngOnDestroy(): void {
     this.navSub.unsubscribe();
-    this.stickIO?.disconnect();
   }
 
   @HostListener("window:resize")
@@ -219,15 +217,6 @@ export class SearchComponent implements OnInit {
   openFilters() {
     this.drawer?.open();
   }
-
-  applyFilters() {
-    if (this.drawer?.opened) {
-      this.mobileFilters?.emitFilters();
-    } else {
-      this.desktopFilters?.emitFilters();
-    }
-  }
-
   /* ========== orden ========== */
   setSort(order: "ASC" | "DESC") {
     if (this.sortOrder === order) return;
@@ -440,30 +429,4 @@ export class SearchComponent implements OnInit {
     this.loadListings(); // ya sincroniza categorías, etc.
   }
 
-  @ViewChild("stickTrigger", { static: false })
-  stickTrigger!: ElementRef<HTMLDivElement>;
-
-  isFixed = false; // bindeo a la clase .is-fixed
-  private stickIO?: IntersectionObserver;
-
-  /* -------- AfterViewInit: activar IntersectionObserver ------ */
-  ngAfterViewInit(): void {
-    if ("IntersectionObserver" in window) {
-      this.stickIO = new IntersectionObserver(
-        ([entry]) => {
-          this.isFixed = entry.isIntersecting;
-          this.cdr.markForCheck();
-        },
-        {
-          root: null, // viewport
-          threshold: 0,
-          // rootMargin opcional: "0px 0px -80px 0px" (activa 80 px antes)
-        }
-      );
-      // podría llegar a renderizar después (ngIf), reintento simple
-      const observe = () =>
-        this.stickIO!.observe(this.stickTrigger.nativeElement);
-      this.stickTrigger ? observe() : setTimeout(observe); // fallback si aún no existe
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- restore green `Filtrar` button within search filters panel
- remove sticky filter button and sentinel logic from search page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68941d730fb88330b6c125457ed44c08