### PR TITLE
chore: remove duplicate head tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -104,37 +104,9 @@
       type="image/png"
     />
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Urbanist:ital,wght@0,100..900;1,100..900&display=swap"
       rel="stylesheet"
-    />
-
-    <!-- Open Graph (lo usan FB, WhatsApp, LinkedIn, Slack, etc.) -->
-    <meta
-      property="og:image"
-      content="https://privium.com/assets/images/og-image.jpg"
-    />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content="Privium - Marketplace Privado…" />
-    <meta
-      property="og:description"
-      content="Marketplace exclusivo para barrios cerrados…"
-    />
-
-    <!-- Twitter Card -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta
-      name="twitter:image"
-      content="https://privium.com/assets/images/twitter-image.jpg"
-    />
-    <meta name="twitter:title" content="Privium - Marketplace Privado" />
-    <meta
-      name="twitter:description"
-      content="Marketplace exclusivo para barrios cerrados…"
     />
   </head>
   <body class="mat-typography">


### PR DESCRIPTION
## Summary
- remove duplicated preconnect, Open Graph, and Twitter meta tags from index.html

## Testing
- `npx ng test neighborhood-marketplace` (fails: Project target does not exist)
- `npm run lint` (fails: Cannot find "lint" target for the specified project)


------
https://chatgpt.com/codex/tasks/task_e_689435e2194883309521d8746732aa2c