### PR TITLE
feat: sort categories alphabetically

### DIFF
--- a/src/app/shared/components/list-categories/list-categories.component.ts
+++ b/src/app/shared/components/list-categories/list-categories.component.ts
@@ -52,7 +52,9 @@ export class ListCategoriesComponent implements OnInit, OnChanges {
   /** Carga desde el backend sólo los hijos de parentId */
   private loadChildren(): void {
     const prefix = this.parentId ? this.parentId + ">" : "";
-    this.categories = this.categoryService.getByPrefix(prefix);
+    this.categories = this.categoryService
+      .getByPrefix(prefix)
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   /** ¿Esta categoría tiene hijos según el flag? */


### PR DESCRIPTION
## Summary
- sort child categories alphabetically when displaying category list

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npx ng test --watch=false` *(fails: Unknown argument: watch)*

------
https://chatgpt.com/codex/tasks/task_e_6895280cae008330a3c6826d7c4004b1