### PR TITLE
Filter categories by type prefix

### DIFF
--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.html
@@ -123,8 +123,8 @@
                 <!-- evita cierre -->
                 <app-list-categories
                   (categorySelected)="onCategorySelected(i, $event)"
-                >
-                </app-list-categories>
+                  [parentId]="typePrefix"
+                ></app-list-categories>
               </div>
             </div>
           </div>

--- a/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
+++ b/src/app/features/profile/my-publishes/edit-publication/edit-publication.component.ts
@@ -80,6 +80,20 @@ export class EditPublicationComponent implements OnInit {
   /* ---------- categorías ----------------------------------- */
   categories: { idPath: string; name: string }[] = [];
   showList: boolean[] = [];
+  private readonly typePrefixes: Record<
+    'PRODUCTO' | 'VEHICULO' | 'MUEBLE' | 'INMUEBLE' | 'SERVICIO',
+    string
+  > = {
+    PRODUCTO: '1',
+    VEHICULO: '2',
+    MUEBLE: '3',
+    INMUEBLE: '4',
+    SERVICIO: '5',
+  };
+
+  get typePrefix(): string {
+    return this.typePrefixes[this.listing.type as keyof typeof this.typePrefixes];
+  }
 
   /* ---------- imágenes ------------------------------------- */
   @ViewChild("fileInput") fileInput!: ElementRef<HTMLInputElement>;

--- a/src/app/features/publish/components/publish/publish.component.html
+++ b/src/app/features/publish/components/publish/publish.component.html
@@ -76,8 +76,8 @@
                 <!-- evita cierre -->
                 <app-list-categories
                   (categorySelected)="onCategorySelected(i, $event)"
-                >
-                </app-list-categories>
+                  [parentId]="typePrefix"
+                ></app-list-categories>
               </div>
             </div>
           </div>

--- a/src/app/features/publish/components/publish/publish.component.ts
+++ b/src/app/features/publish/components/publish/publish.component.ts
@@ -76,6 +76,21 @@ export class PublishComponent implements OnInit {
   type: 'PRODUCTO' | 'VEHICULO' | 'INMUEBLE' | 'MUEBLE' | 'SERVICIO' | null = null;
   skipCondition = false;
 
+  private readonly typePrefixes: Record<
+    'PRODUCTO' | 'VEHICULO' | 'MUEBLE' | 'INMUEBLE' | 'SERVICIO',
+    string
+  > = {
+    PRODUCTO: '1',
+    VEHICULO: '2',
+    MUEBLE: '3',
+    INMUEBLE: '4',
+    SERVICIO: '5',
+  };
+
+  get typePrefix(): string | null {
+    return this.type ? this.typePrefixes[this.type] : null;
+  }
+
   /* ---------------- formularios ---------------- */
   detailsForm!: FormGroup;
   commercialForm!: FormGroup;
@@ -110,6 +125,7 @@ export class PublishComponent implements OnInit {
     if (this.skipCondition) {
       this.detailsForm.get('condition')?.setValue(2);
     }
+    this.resetCategories();
     this.nextStep();
   }
 

--- a/src/app/shared/components/list-categories/list-categories.component.ts
+++ b/src/app/shared/components/list-categories/list-categories.component.ts
@@ -51,9 +51,18 @@ export class ListCategoriesComponent implements OnInit, OnChanges {
 
   /** Carga desde el backend sólo los hijos de parentId */
   private loadChildren(): void {
-    const prefix = this.parentId ? this.parentId + ">" : "";
+    if (this.parentId) {
+      const prefix = this.parentId + ">";
+      this.categories = this.categoryService
+        .getByPrefix(prefix)
+        .sort((a, b) => a.name.localeCompare(b.name));
+      return;
+    }
+
+    // Nivel raíz: mostrar primeras categorías de todos los tipos
     this.categories = this.categoryService
-      .getByPrefix(prefix)
+      .getCached()
+      .filter((c) => c.id.split(">").length === 2)
       .sort((a, b) => a.name.localeCompare(b.name));
   }
 


### PR DESCRIPTION
## Summary
- Limit publish and edit category selectors to the chosen listing type by mapping types to numeric prefixes.
- Display first-level categories across all types when filtering in the header and search views.

## Testing
- `npx ng test --no-watch --browsers=ChromeHeadless` *(fails: Unknown arguments: watch, browsers)*
- `npx ng lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68954cfd01b08330b72be6862f418978