### PR TITLE
feat: sort 'Otros' categories last

### DIFF
--- a/src/app/shared/components/list-categories/list-categories.component.ts
+++ b/src/app/shared/components/list-categories/list-categories.component.ts
@@ -53,17 +53,29 @@ export class ListCategoriesComponent implements OnInit, OnChanges {
   private loadChildren(): void {
     if (this.parentId) {
       const prefix = this.parentId + ">";
-      this.categories = this.categoryService
-        .getByPrefix(prefix)
-        .sort((a, b) => a.name.localeCompare(b.name));
+      this.categories = this.sortCategories(
+        this.categoryService.getByPrefix(prefix)
+      );
       return;
     }
 
     // Nivel raíz: mostrar primeras categorías de todos los tipos
-    this.categories = this.categoryService
-      .getCached()
-      .filter((c) => c.id.split(">").length === 2)
-      .sort((a, b) => a.name.localeCompare(b.name));
+    this.categories = this.sortCategories(
+      this.categoryService
+        .getCached()
+        .filter((c) => c.id.split(">").length === 2)
+    );
+  }
+
+  /** Ordena las categorías alfabéticamente pero deja al final las que comienzan con "Otros" */
+  private sortCategories(list: CategoryResponseDto[]): CategoryResponseDto[] {
+    return list.sort((a, b) => {
+      const aIsOther = a.name.toLowerCase().startsWith("otros");
+      const bIsOther = b.name.toLowerCase().startsWith("otros");
+      if (aIsOther && !bIsOther) return 1;
+      if (!aIsOther && bIsOther) return -1;
+      return a.name.localeCompare(b.name);
+    });
   }
 
   /** ¿Esta categoría tiene hijos según el flag? */


### PR DESCRIPTION
## Summary
- ensure categories beginning with "Otros" appear last in list-categories

## Testing
- `npm test -- --watch=false` (fails: Unknown argument: watch)
- `npm run lint` (fails: Cannot find "lint" target)


------
https://chatgpt.com/codex/tasks/task_e_689567227c9c833098c0b10e2d81f10e