### PR TITLE
feat(auth): improve login page seo

### DIFF
--- a/src/app/features/auth/components/login/login.component.ts
+++ b/src/app/features/auth/components/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormBuilder, Validators, ReactiveFormsModule } from "@angular/forms";
 import { Router } from "@angular/router";
@@ -15,6 +15,7 @@ import { LoginRequest } from "src/app/shared/models/user.model";
 import { HeaderComponent } from "src/app/shared/components/header/header.component";
 import { FooterComponent } from "src/app/shared/components/footer/footer.component";
 import { ResultSnackbarComponent } from "src/app/shared/components/result-snackbar/result.snackbar.component";
+import { SEOService } from "src/app/shared/services/seo.service";
 
 @Component({
   selector: "app-login",
@@ -30,7 +31,7 @@ import { ResultSnackbarComponent } from "src/app/shared/components/result-snackb
   templateUrl: "./login.component.html",
   styleUrls: ["./login.component.scss", "../../auth-styles.scss"],
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
   /** Bandera global de carga / spinner */
   isLoading = false;
 
@@ -73,8 +74,22 @@ export class LoginComponent {
     private fb: FormBuilder,
     private authService: AuthService,
     private router: Router,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private seoService: SEOService
   ) {}
+
+  ngOnInit(): void {
+    this.seoService.updateSEO({
+      title: "Iniciar sesión",
+      description:
+        "Accede a tu cuenta de Privium para comprar y vender en tu barrio cerrado.",
+      keywords: "login, iniciar sesión, privium, acceso, cuenta",
+      url: "https://privium.com/auth/login",
+      type: "website",
+      robots: "noindex, follow",
+      canonical: "https://privium.com/auth/login",
+    });
+  }
 
   /* ------------------------------------------------------------------ */
   /*  ENVÍO DEL FORMULARIO                                              */

--- a/src/app/shared/services/seo.service.ts
+++ b/src/app/shared/services/seo.service.ts
@@ -11,6 +11,8 @@ export interface SEOData {
   author?: string
   publishedTime?: string
   modifiedTime?: string
+  robots?: string
+  canonical?: string
 }
 
 @Injectable({
@@ -66,6 +68,14 @@ export class SEOService {
       this.updateMetaTag("og:title", `${data.title} | Privium`, "property")
       this.updateMetaTag("twitter:title", `${data.title} | Privium`)
     }
+
+    if (data.robots) {
+      this.updateMetaTag("robots", data.robots)
+    }
+
+    if (data.canonical) {
+      this.updateCanonicalLink(data.canonical)
+    }
   }
 
   private updateMetaTag(name: string, content: string, attribute = "name"): void {
@@ -89,5 +99,17 @@ export class SEOService {
   removeStructuredData(): void {
     const scripts = document.querySelectorAll('script[type="application/ld+json"]')
     scripts.forEach((script) => script.remove())
+  }
+
+  private updateCanonicalLink(url: string): void {
+    let link = document.querySelector("link[rel='canonical']")
+    if (link) {
+      link.setAttribute("href", url)
+    } else {
+      link = document.createElement("link")
+      link.setAttribute("rel", "canonical")
+      link.setAttribute("href", url)
+      document.head.appendChild(link)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- enhance SEO service with robots and canonical link support
- initialize login page metadata and canonical URL

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npm test` *(fails: Unknown argument: watch)*

------
https://chatgpt.com/codex/tasks/task_e_6895832a66348330a68b9ede6a9b5bd4