### PR TITLE
Improve home page SEO metadata

### DIFF
--- a/src/app/features/home/components/home/home.component.ts
+++ b/src/app/features/home/components/home/home.component.ts
@@ -190,14 +190,28 @@ export class HomeComponent implements OnInit {
   }
 
   private setupSEO(): void {
+    const description =
+      "Descubre productos únicos en tu barrio cerrado. Marketplace exclusivo y seguro para tu comunidad.";
+    const url = "https://privium.com/home";
+
     this.seoService.updateSEO({
       title: "Inicio",
-      description:
-        "Descubre productos únicos en tu barrio cerrado. Marketplace exclusivo y seguro para tu comunidad.",
+      description,
       keywords:
         "marketplace, barrios cerrados, productos, compra, venta, privium, campos de alvarez",
-      url: "https://privium.com/home",
+      url,
       type: "website",
+      image: "https://privium.com/assets/images/og-image.jpg",
+      author: "Privium",
+      canonical: url,
+    });
+
+    this.seoService.addStructuredData({
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      name: "Inicio | Privium",
+      url,
+      description,
     });
   }
 }

--- a/src/app/shared/services/seo.service.ts
+++ b/src/app/shared/services/seo.service.ts
@@ -11,6 +11,7 @@ export interface SEOData {
   author?: string
   publishedTime?: string
   modifiedTime?: string
+  canonical?: string
 }
 
 @Injectable({
@@ -62,6 +63,10 @@ export class SEOService {
       this.updateMetaTag("article:modified_time", data.modifiedTime, "property")
     }
 
+    if (data.canonical) {
+      this.updateCanonicalLink(data.canonical)
+    }
+
     if (data.title) {
       this.updateMetaTag("og:title", `${data.title} | Privium`, "property")
       this.updateMetaTag("twitter:title", `${data.title} | Privium`)
@@ -89,5 +94,17 @@ export class SEOService {
   removeStructuredData(): void {
     const scripts = document.querySelectorAll('script[type="application/ld+json"]')
     scripts.forEach((script) => script.remove())
+  }
+
+  private updateCanonicalLink(url: string): void {
+    let link = document.querySelector("link[rel='canonical']") as HTMLLinkElement | null
+    if (link) {
+      link.href = url
+    } else {
+      link = document.createElement("link")
+      link.setAttribute("rel", "canonical")
+      link.href = url
+      document.head.appendChild(link)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add canonical link support to SEOService
- enhance home page SEO metadata and structured data

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npx ng test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_6895834094c48330886f55ad7eb807c6