### PR TITLE
chore: enhance home page SEO metadata

### DIFF
--- a/src/app/features/home/components/home/home.component.ts
+++ b/src/app/features/home/components/home/home.component.ts
@@ -196,8 +196,10 @@ export class HomeComponent implements OnInit {
         "Descubre productos únicos en tu barrio cerrado. Marketplace exclusivo y seguro para tu comunidad.",
       keywords:
         "marketplace, barrios cerrados, productos, compra, venta, privium, campos de alvarez",
-      url: "https://privium.com/home",
+      url: "https://privium.com",
       type: "website",
+      image: "https://privium.com/assets/images/og-image.jpg",
+      canonical: "https://privium.com",
     });
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -70,6 +70,10 @@
     />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Privium - Marketplace privado de barrios cerrados"
+    />
     <meta property="og:site_name" content="Privium" />
     <meta property="og:locale" content="es_AR" />
     <meta property="og:locale:alternate" content="es_ES" />


### PR DESCRIPTION
## Summary
- add canonical URL and OG image to home SEO metadata
- include alt text for Open Graph image on index page

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npx ng test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_68961c0a79a88330811e76d93b79ef01